### PR TITLE
chore: update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "easy-purescript-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1710161569,
-        "narHash": "sha256-lcIRIOFCdIWEGyKyG/tB4KvxM9zoWuBRDxW+T+mvIb0=",
+        "lastModified": 1763814099,
+        "narHash": "sha256-YazeA9u0JdxykexV6HHG5DMtsnwqXoiAcWPjncO1XHM=",
         "owner": "justinwoo",
         "repo": "easy-purescript-nix",
-        "rev": "117fd96acb69d7d1727df95b6fde9d8715e031fc",
+        "rev": "8fcd84f54d75d9007b2f1c7c9da5af843105a55f",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
         easy-ps = import easy-purescript-nix { inherit pkgs; };
       in
       {
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           buildInputs = [
             easy-ps.purs-0_15_15
             easy-ps.psc-package
@@ -33,7 +33,7 @@
             easy-ps.zephyr
             pkgs.nodejs
             pkgs.esbuild
-            pkgs.nodePackages.node-gyp
+            pkgs.node-gyp
             pkgs.dhall-lsp-server
             pkgs.autoconf
             pkgs.automake


### PR DESCRIPTION
## Summary
- Update nix flake inputs to current revisions
- Move the development shell output to `devShells.default`
- Replace removed `pkgs.nodePackages.node-gyp` with `pkgs.node-gyp`

## Verification
- `nix flake check`
- `nix develop --command bash -c 'node --version && node-gyp --version && purs --version'`\n- `nix develop --command npm install --legacy-peer-deps`\n- `nix develop --command npm run build`