### PR TITLE
ci: add pull request build workflow

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,0 +1,79 @@
+name: Pull Request Build
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  flake:
+    name: Nix flake
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check flake
+        run: nix flake check
+
+  dependencies:
+    name: Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install npm dependencies
+        run: nix develop -c npm ci --legacy-peer-deps --ignore-scripts
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs:
+      - flake
+      - dependencies
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
+    env:
+      CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+      CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
+      HASURA_ADMIN_SECRET: ${{ secrets.HASURA_ADMIN_SECRET }}
+      GOOGLE_TAGMANAGER_ID: ${{ secrets.GOOGLE_TAGMANAGER_ID }}
+      GOOGLE_TAGMANAGER_AUTH: ${{ secrets.GOOGLE_TAGMANAGER_AUTH }}
+      GOOGLE_TAGMANAGER_PREVIEW: ${{ secrets.GOOGLE_TAGMANAGER_PREVIEW }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check build secrets
+        run: |
+          test -n "$CONTENTFUL_SPACE_ID"
+          test -n "$CONTENTFUL_ACCESS_TOKEN"
+          test -n "$HASURA_ADMIN_SECRET"
+
+      - name: Install npm dependencies
+        run: nix develop -c npm ci --legacy-peer-deps
+
+      - name: Build site
+        run: nix develop -c npm run build


### PR DESCRIPTION
## Summary
- Add a pull request workflow for Nix flake validation
- Validate npm dependency installation without scripts for all PRs
- Run the full Gatsby build only for trusted same-repository PRs where build secrets are available

## Notes
Dependabot and fork PRs do not receive repository secrets, so the full build job is intentionally skipped for those PRs. They still run the flake and dependency checks.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-build.yaml")'`\n- `nix run nixpkgs#actionlint -- .github/workflows/pr-build.yaml`\n- `nix flake check`\n- `nix develop --command npm ci --legacy-peer-deps --ignore-scripts`\n- `nix develop --command npm ci --legacy-peer-deps`\n- `nix develop --command npm run build`