### PR TITLE
refactor: extract Contentful post types

### DIFF
--- a/src/components/molecules/Card.tsx
+++ b/src/components/molecules/Card.tsx
@@ -2,9 +2,10 @@ import React from "react"
 import { GatsbyImage } from "gatsby-plugin-image"
 import ReadingTime from "../atoms/ReadingTime"
 import Date from "../atoms/Date"
+import type { ContentfulPost } from "../../types/contentful"
 
 type Props = {
-  post: Queries.ContentfulPost
+  post: ContentfulPost
 }
 
 const Card: React.FC<Props> = ({ post }) => (

--- a/src/components/organisms/Blog.tsx
+++ b/src/components/organisms/Blog.tsx
@@ -1,10 +1,11 @@
 import React from "react"
 import Card from "../molecules/Card"
+import type { ContentfulPost } from "../../types/contentful"
 
 type Props = {
   title: string
   caption: string
-  children: Array<Queries.ContentfulPost>
+  children: Array<ContentfulPost>
 }
 
 const Blog: React.FC<Props> = ({ title, caption, children }) => (

--- a/src/templates/Blog/Post.tsx
+++ b/src/templates/Blog/Post.tsx
@@ -7,12 +7,13 @@ import Tags from "../../components/atoms/Tags"
 import Hero from "../../components/molecules/Hero"
 import StyledMDXComponent from "../../components/StyledMDXComponent"
 import DummyText from "../../constants/Dummy/Text"
+import type { ContentfulPost } from "../../types/contentful"
 
 type Props = {
   data: {
-    post: Queries.ContentfulPost
-    previous: Queries.ContentfulPost
-    next: Queries.ContentfulPost
+    post: ContentfulPost
+    previous: ContentfulPost | null
+    next: ContentfulPost | null
   }
 }
 
@@ -32,7 +33,7 @@ const Post: React.FC<Props> = props => {
     imageSrc = getSrc(post.heroImage.gatsbyImageData)
   }
   const body = post.body?.body ?? DummyText
-  const tags = (post.tags as Array<string>) ?? ["No tags."]
+  const tags = post.tags ?? ["No tags."]
 
   return (
     <div className="relative mx-auto max-w-7xl bg-white px-4 py-16 sm:px-6 md:justify-between lg:px-8 lg:pb-28 lg:pt-8">

--- a/src/templates/Blog/Posts.tsx
+++ b/src/templates/Blog/Posts.tsx
@@ -1,11 +1,12 @@
 import React from "react"
 import { graphql } from "gatsby"
 import Blog from "../../components/organisms/Blog"
+import type { ContentfulPost } from "../../types/contentful"
 
 type Props = {
   data: {
     posts: {
-      nodes: Array<Queries.ContentfulPost>
+      nodes: Array<ContentfulPost>
     }
   }
   pageContext: {

--- a/src/types/contentful.ts
+++ b/src/types/contentful.ts
@@ -1,0 +1,33 @@
+import type { IGatsbyImageData } from "gatsby-plugin-image"
+
+type Nullable<T> = T | null | undefined
+
+export type ContentfulImage = {
+  gatsbyImageData?: Nullable<IGatsbyImageData>
+  resize?: Nullable<{
+    src?: Nullable<string>
+  }>
+}
+
+export type ContentfulAuthor = {
+  identity?: Nullable<string>
+  name?: Nullable<string>
+  picture?: Nullable<ContentfulImage>
+  profile?: Nullable<string>
+}
+
+export type ContentfulPost = {
+  authors?: Nullable<Array<Nullable<ContentfulAuthor>>>
+  body?: Nullable<{
+    body?: Nullable<string>
+  }>
+  description?: Nullable<{
+    description?: Nullable<string>
+  }>
+  heroImage?: Nullable<ContentfulImage>
+  publishedOn?: Nullable<string>
+  rawDate?: Nullable<string>
+  slug?: Nullable<string>
+  tags?: Nullable<Array<string>>
+  title?: Nullable<string>
+}


### PR DESCRIPTION
## Summary
- Add `src/types/contentful.ts` with local `ContentfulPost`, `ContentfulAuthor`, and `ContentfulImage` types.
- Replace `Queries.ContentfulPost` props in Blog/Card/Post/Posts with the local content types.
- Keep the Gatsby GraphQL queries unchanged.

## Why
This separates the blog rendering layer from Gatsby's generated `Queries.*` types, which is a useful step before replacing Gatsby's data layer with direct Contentful/Astro data loading.

## Verification
- `nix develop --command npm run lint`
- Covered by the local `nix develop --command npm run build` run on the stacked `refactor/wrap-gatsby-image` branch.

## Notes
- `npm run lint` exits successfully, with the existing generated `src/gatsby-types.d.ts` unused eslint-disable warning.
