### PR TITLE
refactor: wrap Gatsby image usage

### DIFF
--- a/src/components/atoms/Image.tsx
+++ b/src/components/atoms/Image.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { GatsbyImage, getSrc } from "gatsby-plugin-image"
+import type { IGatsbyImageData } from "gatsby-plugin-image"
+
+export type ImageData = IGatsbyImageData
+
+type Props = {
+  alt: string
+  className?: string
+  image: ImageData
+}
+
+const Image: React.FC<Props> = ({ alt, className, image }) => (
+  <GatsbyImage alt={alt} className={className} image={image} />
+)
+
+const getImageSrc = (image: ImageData) => getSrc(image)
+
+export { getImageSrc }
+export default Image

--- a/src/components/molecules/Card.tsx
+++ b/src/components/molecules/Card.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { GatsbyImage } from "gatsby-plugin-image"
+import Image from "../atoms/Image"
 import ReadingTime from "../atoms/ReadingTime"
 import Date from "../atoms/Date"
 import type { ContentfulPost } from "../../types/contentful"
@@ -15,7 +15,7 @@ const Card: React.FC<Props> = ({ post }) => (
   >
     <div className="shrink-0">
       {post.heroImage?.gatsbyImageData && (
-        <GatsbyImage
+        <Image
           className="h-48 w-full object-cover"
           alt=""
           image={post.heroImage.gatsbyImageData}
@@ -44,7 +44,7 @@ const Card: React.FC<Props> = ({ post }) => (
             <a href={`/blog/author/${author?.identity}`}>
               <span className="sr-only">{author?.name}</span>
               {author?.picture?.gatsbyImageData && (
-                <GatsbyImage
+                <Image
                   className="h-10 w-10 rounded-full"
                   alt=""
                   image={author?.picture?.gatsbyImageData}

--- a/src/components/molecules/Hero.tsx
+++ b/src/components/molecules/Hero.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image"
+import Image from "../atoms/Image"
+import type { ImageData } from "../atoms/Image"
 
 type Props = {
-  image?: IGatsbyImageData
+  image?: ImageData
   title: string
   content?: string
 }
@@ -10,7 +11,7 @@ type Props = {
 const Hero: React.FC<Props> = ({ image, title, content }) => (
   <div>
     {image && (
-      <GatsbyImage
+      <Image
         alt={title}
         image={image}
         className="h-96 w-full object-cover"

--- a/src/templates/Blog/Post.tsx
+++ b/src/templates/Blog/Post.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql, Link } from "gatsby"
-import { getSrc } from "gatsby-plugin-image"
+import { getImageSrc } from "../../components/atoms/Image"
 import useReadingTime from "../../hooks/useReadingTime"
 import SEO from "../../components/SEO"
 import Tags from "../../components/atoms/Tags"
@@ -30,7 +30,7 @@ const Post: React.FC<Props> = props => {
   const { minutes } = useReadingTime(post.body?.body ?? "No body.")
   let imageSrc
   if (post.heroImage?.gatsbyImageData) {
-    imageSrc = getSrc(post.heroImage.gatsbyImageData)
+    imageSrc = getImageSrc(post.heroImage.gatsbyImageData)
   }
   const body = post.body?.body ?? DummyText
   const tags = post.tags ?? ["No tags."]


### PR DESCRIPTION
## Summary
- Add a small Image component wrapper around GatsbyImage
- Route existing card, hero, and blog post image usages through the wrapper
- Keep the change narrow so Gatsby-specific image rendering has one migration point before Astro work

Replaces closed stacked PR #27 after #26 was merged.

## Verification
- nix develop --command npm run lint
- nix develop --command npm run build
