### PR TITLE
refactor: separate route views from Gatsby templates

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -34,7 +34,7 @@ const config: GatsbyConfig = {
     {
       resolve: `gatsby-plugin-purgecss`,
       options: {
-        content: [`gatsby-ssr.ts`, `src/**.*.tsx`, `purs/**/*.purs`],
+        content: [`gatsby-ssr.tsx`, `src/**/*.tsx`, `purs/**/*.purs`],
         tailwind: true,
         purgeOnly: [`styles/styles.css`],
       },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,18 +1,13 @@
 import { navigate } from "gatsby"
 import React, { useEffect } from "react"
+import IndexView from "../views/IndexView"
 
-const Contents: React.FC = () => {
+const Index: React.FC = () => {
   useEffect(() => {
     navigate("/blog/")
-  })
+  }, [])
 
-  return (
-    <div className="prose relative mx-auto max-w-7xl bg-white px-4 pb-20 pt-16 sm:px-6 md:justify-between lg:px-8 lg:pb-28 lg:pt-24">
-      Under development.
-    </div>
-  )
+  return <IndexView />
 }
-
-const Index: React.FC = () => <Contents />
 
 export default Index

--- a/src/templates/Blog/Post.tsx
+++ b/src/templates/Blog/Post.tsx
@@ -1,13 +1,10 @@
 import React from "react"
-import { Link } from "gatsby"
-import { getImageSrc } from "../../components/atoms/Image"
-import useReadingTime from "../../hooks/useReadingTime"
 import SEO from "../../components/SEO"
-import Tags from "../../components/atoms/Tags"
-import Hero from "../../components/molecules/Hero"
-import StyledMDXComponent from "../../components/StyledMDXComponent"
-import DummyText from "../../constants/Dummy/Text"
-import Date from "../../components/atoms/Date"
+import BlogPostView, {
+  getBlogPostDescription,
+  getBlogPostImageSrc,
+  getBlogPostTitle,
+} from "../../views/BlogPostView"
 import type { BlogPost, BlogPostPreview } from "../../types/content"
 
 type Props = {
@@ -21,67 +18,15 @@ type Props = {
 const Post: React.FC<Props> = props => {
   const { post, previous, next } = props.pageContext
 
-  const title = post.title ?? "No title."
-  const description = post.description ?? "No description given."
-  const authors = ((): string => {
-    const names = post.authors?.map(author => author?.name)
-    if (names) return names.join(", ")
-    return "John Due"
-  })()
-  const { minutes } = useReadingTime(post.body)
-  let imageSrc
-  if (post.heroImage) {
-    imageSrc = getImageSrc(post.heroImage)
-  }
-  const body = post.body ?? DummyText
-  const tags = post.tags ?? ["No tags."]
+  const title = getBlogPostTitle(post)
+  const description = getBlogPostDescription(post)
+  const imageSrc = getBlogPostImageSrc(post)
 
   return (
-    <div className="relative mx-auto max-w-7xl bg-white px-4 py-16 sm:px-6 md:justify-between lg:px-8 lg:pb-28 lg:pt-8">
+    <>
       <SEO title={title} description={description} image={imageSrc} />
-      {post.heroImage && (
-        <Hero image={post.heroImage} title={title} content={description} />
-      )}
-      <div className="flex items-center justify-between">
-        <Tags tags={tags} />
-        <div className="text-base font-thin text-slate-700">
-          {authors} &middot;&nbsp;
-          {post.publishedOn && <Date>{post.publishedOn}</Date>}– {minutes}{" "}
-          minute read
-        </div>
-      </div>
-      <div className="prose max-w-full">
-        <div>{StyledMDXComponent(body)}</div>
-        {(previous || next) && (
-          <nav>
-            <ul className="flow-root list-none px-0 py-6 text-base font-thin text-slate-700">
-              {previous && (
-                <li className="p-0">
-                  <Link
-                    className="float-left"
-                    to={`/blog/post/${previous.slug}`}
-                    rel="prev"
-                  >
-                    ← {previous.title}
-                  </Link>
-                </li>
-              )}
-              {next && (
-                <li className="p-0">
-                  <Link
-                    className="float-right"
-                    to={`/blog/post/${next.slug}`}
-                    rel="next"
-                  >
-                    {next.title} →
-                  </Link>
-                </li>
-              )}
-            </ul>
-          </nav>
-        )}
-      </div>
-    </div>
+      <BlogPostView post={post} previous={previous} next={next} />
+    </>
   )
 }
 

--- a/src/templates/Blog/Posts.tsx
+++ b/src/templates/Blog/Posts.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import Blog from "../../components/organisms/Blog"
+import BlogPostsView from "../../views/BlogPostsView"
 import type { BlogPost } from "../../types/content"
 
 type Props = {
@@ -11,9 +11,11 @@ type Props = {
 }
 
 const Posts: React.FC<Props> = ({ pageContext }) => (
-  <Blog title={pageContext.title} caption={pageContext.caption}>
-    {pageContext.posts}
-  </Blog>
+  <BlogPostsView
+    title={pageContext.title}
+    caption={pageContext.caption}
+    posts={pageContext.posts}
+  />
 )
 
 export default Posts

--- a/src/templates/Page.tsx
+++ b/src/templates/Page.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import StyledMDXComponent from "../components/StyledMDXComponent"
+import PageView from "../views/PageView"
 import type { PageContent } from "../types/content"
 
 type Props = {
@@ -9,12 +9,7 @@ type Props = {
 }
 
 const Page: React.FC<Props> = ({ pageContext }) => (
-  <div className="prose relative mx-auto max-w-7xl bg-white px-4 pb-20 pt-16 sm:px-6 md:justify-between lg:px-8 lg:pb-28 lg:pt-24">
-    <h1 className="border-b border-slate-500 pb-4 text-2xl text-slate-700">
-      {pageContext.page.title}
-    </h1>
-    {StyledMDXComponent(pageContext.page.body)}
-  </div>
+  <PageView page={pageContext.page} />
 )
 
 export default Page

--- a/src/views/BlogPostView.tsx
+++ b/src/views/BlogPostView.tsx
@@ -1,0 +1,91 @@
+import React from "react"
+import { getImageSrc } from "../components/atoms/Image"
+import useReadingTime from "../hooks/useReadingTime"
+import Tags from "../components/atoms/Tags"
+import Hero from "../components/molecules/Hero"
+import StyledMDXComponent from "../components/StyledMDXComponent"
+import DummyText from "../constants/Dummy/Text"
+import Date from "../components/atoms/Date"
+import type { BlogPost, BlogPostPreview } from "../types/content"
+
+export type BlogPostViewProps = {
+  next: BlogPostPreview | null
+  post: BlogPost
+  previous: BlogPostPreview | null
+}
+
+export const getBlogPostTitle = (post: BlogPost) => post.title ?? "No title."
+
+export const getBlogPostDescription = (post: BlogPost) =>
+  post.description ?? "No description given."
+
+export const getBlogPostImageSrc = (post: BlogPost) =>
+  post.heroImage ? getImageSrc(post.heroImage) : undefined
+
+const getBlogPostAuthors = (post: BlogPost) => {
+  const names = post.authors?.map(author => author?.name)
+  if (names) return names.join(", ")
+  return "John Due"
+}
+
+const BlogPostView: React.FC<BlogPostViewProps> = ({
+  post,
+  previous,
+  next,
+}) => {
+  const title = getBlogPostTitle(post)
+  const description = getBlogPostDescription(post)
+  const authors = getBlogPostAuthors(post)
+  const { minutes } = useReadingTime(post.body)
+  const body = post.body ?? DummyText
+  const tags = post.tags ?? ["No tags."]
+
+  return (
+    <div className="relative mx-auto max-w-7xl bg-white px-4 py-16 sm:px-6 md:justify-between lg:px-8 lg:pb-28 lg:pt-8">
+      {post.heroImage && (
+        <Hero image={post.heroImage} title={title} content={description} />
+      )}
+      <div className="flex items-center justify-between">
+        <Tags tags={tags} />
+        <div className="text-base font-thin text-slate-700">
+          {authors} &middot;&nbsp;
+          {post.publishedOn && <Date>{post.publishedOn}</Date>}– {minutes}{" "}
+          minute read
+        </div>
+      </div>
+      <div className="prose max-w-full">
+        <div>{StyledMDXComponent(body)}</div>
+        {(previous || next) && (
+          <nav>
+            <ul className="flow-root list-none px-0 py-6 text-base font-thin text-slate-700">
+              {previous && (
+                <li className="p-0">
+                  <a
+                    className="float-left"
+                    href={`/blog/post/${previous.slug}`}
+                    rel="prev"
+                  >
+                    ← {previous.title}
+                  </a>
+                </li>
+              )}
+              {next && (
+                <li className="p-0">
+                  <a
+                    className="float-right"
+                    href={`/blog/post/${next.slug}`}
+                    rel="next"
+                  >
+                    {next.title} →
+                  </a>
+                </li>
+              )}
+            </ul>
+          </nav>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default BlogPostView

--- a/src/views/BlogPostsView.tsx
+++ b/src/views/BlogPostsView.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+import Blog from "../components/organisms/Blog"
+import type { BlogPost } from "../types/content"
+
+export type BlogPostsViewProps = {
+  caption?: string
+  posts: Array<BlogPost>
+  title: string
+}
+
+const BlogPostsView: React.FC<BlogPostsViewProps> = ({
+  title,
+  caption,
+  posts,
+}) => (
+  <Blog title={title} caption={caption}>
+    {posts}
+  </Blog>
+)
+
+export default BlogPostsView

--- a/src/views/IndexView.tsx
+++ b/src/views/IndexView.tsx
@@ -1,0 +1,9 @@
+import React from "react"
+
+const IndexView: React.FC = () => (
+  <div className="prose relative mx-auto max-w-7xl bg-white px-4 pb-20 pt-16 sm:px-6 md:justify-between lg:px-8 lg:pb-28 lg:pt-24">
+    Under development.
+  </div>
+)
+
+export default IndexView

--- a/src/views/PageView.tsx
+++ b/src/views/PageView.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import StyledMDXComponent from "../components/StyledMDXComponent"
+import type { PageContent } from "../types/content"
+
+export type PageViewProps = {
+  page: PageContent
+}
+
+const PageView: React.FC<PageViewProps> = ({ page }) => (
+  <div className="prose relative mx-auto max-w-7xl bg-white px-4 pb-20 pt-16 sm:px-6 md:justify-between lg:px-8 lg:pb-28 lg:pt-24">
+    <h1 className="border-b border-slate-500 pb-4 text-2xl text-slate-700">
+      {page.title}
+    </h1>
+    {StyledMDXComponent(page.body)}
+  </div>
+)
+
+export default PageView

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -5,6 +5,7 @@ export default {
     "./src/pages/**/*.tsx",
     "./src/components/**/*.tsx",
     "./src/templates/**/*.tsx",
+    "./src/views/**/*.tsx",
     "./purs/**/*.purs",
   ],
   theme: {
@@ -14,5 +15,5 @@ export default {
       },
     },
   },
-  plugins: [ typography ],
+  plugins: [typography],
 }


### PR DESCRIPTION
## Summary
- move blog post, blog listing, page, and index rendering into framework-neutral React view components under src/views
- keep Gatsby pageContext handling, navigation, and SEO in the Gatsby page/template adapters
- replace the blog post previous/next Gatsby Link usage inside the view with plain anchors
- update Tailwind/PurgeCSS content globs so moved view classes remain discoverable

This preserves the current routes and rendering while making the visible route views reusable for the Astro migration.

## Verification
- npm run lint
- npx tsc --noEmit
- npm run check:content
- npm run clean
- npm run build
- npm run check:routes
- npm audit --json
- nix flake check