### PR TITLE
refactor: extract content route data

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,8 +1,8 @@
-import { GatsbyNode, CreateWebpackConfigArgs } from "gatsby"
-import { readdirSync, readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { NormalModuleReplacementPlugin, ProvidePlugin } from "webpack"
-import type { BlogPost, PageContent } from "./src/types/content"
+import { loadBlogPosts, loadPages } from "./src/lib/content"
+import { buildSiteRouteData } from "./src/lib/routeData"
+import type { CreateWebpackConfigArgs, GatsbyNode } from "gatsby"
 
 const onCreateWebpackConfig = ({ actions }: CreateWebpackConfigArgs) => {
   actions.setWebpackConfig({
@@ -24,97 +24,7 @@ const onCreateWebpackConfig = ({ actions }: CreateWebpackConfigArgs) => {
   })
 }
 
-type Frontmatter = Record<string, unknown>
-
-type MdxDocument<TFrontmatter extends Frontmatter> = {
-  body: string
-  frontmatter: TFrontmatter
-}
-
-const blogCaption =
-  "Grammatica loquitur, Dialectia vera docet, Rhetorica verba ministrat, Musica canit, Arithmetica munerat, Geometrica ponderat, Astronomica colit astra."
-
 const contentDirectory = resolve(__dirname, "src", "content")
-
-const readMdxCollection = <TFrontmatter extends Frontmatter>(
-  collection: string,
-): Array<MdxDocument<TFrontmatter>> => {
-  const collectionDirectory = resolve(contentDirectory, collection)
-  return readdirSync(collectionDirectory)
-    .filter(fileName => fileName.endsWith(".mdx"))
-    .map(fileName => {
-      const file = readFileSync(resolve(collectionDirectory, fileName), "utf8")
-      return parseMdxDocument<TFrontmatter>(file)
-    })
-}
-
-const parseMdxDocument = <TFrontmatter extends Frontmatter>(
-  file: string,
-): MdxDocument<TFrontmatter> => {
-  const match = /^---\n(?<frontmatter>[\s\S]*?)\n---\n?(?<body>[\s\S]*)$/u.exec(
-    file,
-  )
-  if (!match?.groups) {
-    throw new Error("MDX file is missing frontmatter.")
-  }
-
-  return {
-    frontmatter: parseFrontmatter(match.groups["frontmatter"] ?? ""),
-    body: match.groups["body"]?.trim() ?? "",
-  }
-}
-
-const parseFrontmatter = <TFrontmatter extends Frontmatter>(
-  frontmatter: string,
-) =>
-  Object.fromEntries(
-    frontmatter
-      .split("\n")
-      .filter(line => line.trim().length > 0)
-      .map(line => {
-        const separatorIndex = line.indexOf(":")
-        if (separatorIndex === -1) {
-          throw new Error(`Invalid frontmatter line: ${line}`)
-        }
-
-        const key = line.slice(0, separatorIndex).trim()
-        const value = line.slice(separatorIndex + 1).trim()
-        return [key, JSON.parse(value)]
-      }),
-  ) as TFrontmatter
-
-const loadBlogPosts = (): Array<BlogPost> =>
-  readMdxCollection<Omit<BlogPost, "body">>("blog")
-    .map(({ frontmatter, body }) => ({
-      ...frontmatter,
-      body,
-    }))
-    .sort((left, right) =>
-      String(right.publishedOn ?? "").localeCompare(
-        String(left.publishedOn ?? ""),
-      ),
-    )
-
-const loadPages = (): Array<PageContent> =>
-  readMdxCollection<Omit<PageContent, "body">>("pages").map(
-    ({ frontmatter, body }) => ({
-      ...frontmatter,
-      body,
-    }),
-  )
-
-const uniqueTags = (posts: Array<BlogPost>) =>
-  Array.from(new Set(posts.flatMap(post => post.tags ?? [])))
-
-const uniqueAuthors = (posts: Array<BlogPost>) =>
-  Array.from(
-    posts
-      .flatMap(post => post.authors ?? [])
-      .reduce((authors, author) => {
-        if (author.identity) authors.set(author.identity, author)
-        return authors
-      }, new Map()),
-  ).map(([, author]) => author)
 
 const createPages: GatsbyNode["createPages"] = async ({ actions }) => {
   const { createPage } = actions
@@ -123,66 +33,43 @@ const createPages: GatsbyNode["createPages"] = async ({ actions }) => {
   const postsTemplate = resolve("./src/templates/Blog/Posts.tsx")
   const pageTemplate = resolve("./src/templates/Page.tsx")
 
-  const posts = loadBlogPosts()
-  const pages = loadPages()
+  const routeData = buildSiteRouteData({
+    posts: loadBlogPosts(contentDirectory),
+    pages: loadPages(contentDirectory),
+  })
 
-  posts.forEach((post, index) => {
+  routeData.blogPosts.forEach(route => {
     createPage({
-      path: `/blog/post/${post.slug}/`,
+      path: route.path,
       component: postTemplate,
       context: {
-        post,
-        previous: posts[index + 1] ?? null,
-        next: posts[index - 1] ?? null,
+        post: route.post,
+        previous: route.previous,
+        next: route.next,
       },
     })
   })
 
-  createPage({
-    path: `/blog/`,
-    component: postsTemplate,
-    context: {
-      title: `Blog`,
-      caption: blogCaption,
-      posts,
-    },
-  })
-
-  uniqueTags(posts).forEach(tag => {
+  routeData.blogPostIndexes.forEach(route => {
     createPage({
-      path: `/blog/tag/${tag}/`,
+      path: route.path,
       component: postsTemplate,
       context: {
-        title: `Tag: ${tag}`,
-        tag,
-        posts: posts.filter(post => post.tags?.includes(tag)),
+        title: route.title,
+        caption: route.caption,
+        tag: route.tag,
+        authorId: route.authorId,
+        posts: route.posts,
       },
     })
   })
 
-  uniqueAuthors(posts).forEach(author => {
+  routeData.pages.forEach(route => {
     createPage({
-      path: `/blog/author/${author.identity}/`,
-      component: postsTemplate,
-      context: {
-        title: `Author: ${author.name}`,
-        caption: author.profile,
-        authorId: author.identity,
-        posts: posts.filter(post =>
-          post.authors?.some(
-            postAuthor => postAuthor.identity === author.identity,
-          ),
-        ),
-      },
-    })
-  })
-
-  pages.forEach(page => {
-    createPage({
-      path: `/${page.slug}/`,
+      path: route.path,
       component: pageTemplate,
       context: {
-        page,
+        page: route.page,
       },
     })
   })

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,0 +1,100 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import type { BlogPost, ContentAuthor, PageContent } from "../types/content"
+
+type Frontmatter = Record<string, unknown>
+
+type MdxDocument<TFrontmatter extends Frontmatter> = {
+  body: string
+  frontmatter: TFrontmatter
+}
+
+export const blogCaption =
+  "Grammatica loquitur, Dialectia vera docet, Rhetorica verba ministrat, Musica canit, Arithmetica munerat, Geometrica ponderat, Astronomica colit astra."
+
+export const defaultContentDirectory = resolve(process.cwd(), "src", "content")
+
+export const loadBlogPosts = (
+  contentDirectory = defaultContentDirectory,
+): Array<BlogPost> =>
+  readMdxCollection<Omit<BlogPost, "body">>(contentDirectory, "blog")
+    .map(({ frontmatter, body }) => ({
+      ...frontmatter,
+      body,
+    }))
+    .sort((left, right) =>
+      String(right.publishedOn ?? "").localeCompare(
+        String(left.publishedOn ?? ""),
+      ),
+    )
+
+export const loadPages = (
+  contentDirectory = defaultContentDirectory,
+): Array<PageContent> =>
+  readMdxCollection<Omit<PageContent, "body">>(contentDirectory, "pages").map(
+    ({ frontmatter, body }) => ({
+      ...frontmatter,
+      body,
+    }),
+  )
+
+export const uniqueTags = (posts: Array<BlogPost>) =>
+  Array.from(new Set(posts.flatMap(post => post.tags ?? [])))
+
+export const uniqueAuthors = (posts: Array<BlogPost>) =>
+  Array.from(
+    posts
+      .flatMap(post => post.authors ?? [])
+      .reduce<Map<string, ContentAuthor>>((authors, author) => {
+        if (author.identity) authors.set(author.identity, author)
+        return authors
+      }, new Map()),
+  ).map(([, author]) => author)
+
+const readMdxCollection = <TFrontmatter extends Frontmatter>(
+  contentDirectory: string,
+  collection: string,
+): Array<MdxDocument<TFrontmatter>> => {
+  const collectionDirectory = resolve(contentDirectory, collection)
+  return readdirSync(collectionDirectory)
+    .filter(fileName => fileName.endsWith(".mdx"))
+    .map(fileName => {
+      const file = readFileSync(resolve(collectionDirectory, fileName), "utf8")
+      return parseMdxDocument<TFrontmatter>(file)
+    })
+}
+
+const parseMdxDocument = <TFrontmatter extends Frontmatter>(
+  file: string,
+): MdxDocument<TFrontmatter> => {
+  const match = /^---\n(?<frontmatter>[\s\S]*?)\n---\n?(?<body>[\s\S]*)$/u.exec(
+    file,
+  )
+  if (!match?.groups) {
+    throw new Error("MDX file is missing frontmatter.")
+  }
+
+  return {
+    frontmatter: parseFrontmatter(match.groups["frontmatter"] ?? ""),
+    body: match.groups["body"]?.trim() ?? "",
+  }
+}
+
+const parseFrontmatter = <TFrontmatter extends Frontmatter>(
+  frontmatter: string,
+) =>
+  Object.fromEntries(
+    frontmatter
+      .split("\n")
+      .filter(line => line.trim().length > 0)
+      .map(line => {
+        const separatorIndex = line.indexOf(":")
+        if (separatorIndex === -1) {
+          throw new Error(`Invalid frontmatter line: ${line}`)
+        }
+
+        const key = line.slice(0, separatorIndex).trim()
+        const value = line.slice(separatorIndex + 1).trim()
+        return [key, JSON.parse(value)]
+      }),
+  ) as TFrontmatter

--- a/src/lib/routeData.ts
+++ b/src/lib/routeData.ts
@@ -1,0 +1,112 @@
+import { blogCaption, uniqueAuthors, uniqueTags } from "./content"
+import type { BlogPost, BlogPostPreview, PageContent } from "../types/content"
+
+export type BlogPostRouteData = {
+  next: BlogPostPreview | null
+  path: string
+  post: BlogPost
+  previous: BlogPostPreview | null
+}
+
+export type BlogPostsRouteData = {
+  authorId?: string
+  caption?: string
+  path: string
+  posts: Array<BlogPost>
+  tag?: string
+  title: string
+}
+
+export type PageRouteData = {
+  page: PageContent
+  path: string
+}
+
+export type SiteRouteData = {
+  blogPosts: Array<BlogPostRouteData>
+  blogPostIndexes: Array<BlogPostsRouteData>
+  pages: Array<PageRouteData>
+}
+
+export const buildSiteRouteData = ({
+  posts,
+  pages,
+}: {
+  pages: Array<PageContent>
+  posts: Array<BlogPost>
+}): SiteRouteData => ({
+  blogPosts: buildBlogPostRouteData(posts),
+  blogPostIndexes: [
+    buildBlogIndexRouteData(posts),
+    ...buildBlogTagRouteData(posts),
+    ...buildBlogAuthorRouteData(posts),
+  ],
+  pages: buildPageRouteData(pages),
+})
+
+export const blogPostPath = (post: BlogPost) =>
+  `/blog/post/${requireString("blog post slug", post.slug)}/`
+
+export const blogTagPath = (tag: string) => `/blog/tag/${tag}/`
+
+export const blogAuthorPath = (authorId: string) => `/blog/author/${authorId}/`
+
+export const pagePath = (page: PageContent) =>
+  `/${requireString("page slug", page.slug)}/`
+
+const buildBlogPostRouteData = (
+  posts: Array<BlogPost>,
+): Array<BlogPostRouteData> =>
+  posts.map((post, index) => ({
+    path: blogPostPath(post),
+    post,
+    previous: posts[index + 1] ?? null,
+    next: posts[index - 1] ?? null,
+  }))
+
+const buildBlogIndexRouteData = (
+  posts: Array<BlogPost>,
+): BlogPostsRouteData => ({
+  path: "/blog/",
+  title: "Blog",
+  caption: blogCaption,
+  posts,
+})
+
+const buildBlogTagRouteData = (
+  posts: Array<BlogPost>,
+): Array<BlogPostsRouteData> =>
+  uniqueTags(posts).map(tag => ({
+    path: blogTagPath(tag),
+    title: `Tag: ${tag}`,
+    tag,
+    posts: posts.filter(post => post.tags?.includes(tag)),
+  }))
+
+const buildBlogAuthorRouteData = (
+  posts: Array<BlogPost>,
+): Array<BlogPostsRouteData> =>
+  uniqueAuthors(posts).map(author => {
+    const authorId = requireString("author identity", author.identity)
+
+    return {
+      path: blogAuthorPath(authorId),
+      title: `Author: ${author.name}`,
+      caption: author.profile ?? undefined,
+      authorId,
+      posts: posts.filter(post =>
+        post.authors?.some(postAuthor => postAuthor.identity === authorId),
+      ),
+    }
+  })
+
+const buildPageRouteData = (pages: Array<PageContent>): Array<PageRouteData> =>
+  pages.map(page => ({
+    path: pagePath(page),
+    page,
+  }))
+
+const requireString = (name: string, value: string | null | undefined) => {
+  if (typeof value === "string" && value.trim().length > 0) return value
+  throw new Error(`${name} must be a non-empty string.`)
+}


### PR DESCRIPTION
## Summary
- move local MDX content loading from gatsby-node.ts into src/lib/content.ts
- move route data generation for posts, indexes, authors, tags, and pages into src/lib/routeData.ts
- keep gatsby-node.ts focused on wiring generated route data into Gatsby createPage

This keeps current Gatsby routes intact while making the content and route data reusable from an Astro entrypoint later.

## Verification
- npm run lint
- npx tsc --noEmit
- npm run check:content
- npm run clean
- npm run build
- npm run check:routes
- npm audit --json
- nix flake check