### PR TITLE
refactor: extract seo metadata

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,77 +1,20 @@
 import * as React from "react"
 import { Helmet } from "react-helmet"
-import { siteMetadata } from "../config/siteMetadata"
+import { buildSeoData } from "../lib/seo"
+import type { SeoInput } from "../lib/seo"
 
-type Lang = "en" | "ja"
-
-type Props = {
-  lang?: Lang
-  title: string
-  description?: string
-  meta?: Array<HTMLMetaElement>
-  image: string | undefined
-}
-
-const SEO: React.FC<Props> = ({
-  lang = "en",
-  title,
-  description = "",
-  meta = [],
-  image,
-}) => {
-  const metaDescription = description || siteMetadata.description
-  const defaultTitle = siteMetadata.title
+const SEO: React.FC<SeoInput> = props => {
+  const seo = buildSeoData(props)
 
   return (
     <Helmet
       htmlAttributes={{
-        lang,
+        lang: seo.lang,
       }}
-      title={title}
-      defaultTitle={defaultTitle}
-      titleTemplate={defaultTitle ? `%s | ${defaultTitle}` : undefined}
-      meta={[
-        {
-          name: `description`,
-          content: metaDescription,
-        },
-        {
-          name: `image`,
-          content: image,
-        },
-        {
-          property: `og:title`,
-          content: title,
-        },
-        {
-          property: `og:description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:type`,
-          content: `website`,
-        },
-        {
-          property: `og:image`,
-          content: image,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary_large_image`,
-        },
-        {
-          name: `twitter:creator`,
-          content: siteMetadata.author.twitter,
-        },
-        {
-          name: `twitter:title`,
-          content: title,
-        },
-        {
-          name: `twitter:description`,
-          content: metaDescription,
-        },
-      ].concat(meta)}
+      title={seo.title}
+      defaultTitle={seo.defaultTitle}
+      titleTemplate={seo.titleTemplate}
+      meta={seo.meta}
     />
   )
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,86 @@
+import { siteMetadata } from "../config/siteMetadata"
+
+export type HtmlLang = "en" | "ja"
+
+export type SeoMeta = {
+  content?: string
+  name?: string
+  property?: string
+}
+
+export type SeoInput = {
+  description?: string
+  image?: string
+  lang?: HtmlLang
+  meta?: Array<SeoMeta>
+  title: string
+}
+
+export type SeoData = {
+  defaultTitle: string
+  lang: HtmlLang
+  meta: Array<SeoMeta>
+  title: string
+  titleTemplate: string | undefined
+}
+
+export const buildSeoData = ({
+  lang = "en",
+  title,
+  description = "",
+  meta = [],
+  image,
+}: SeoInput): SeoData => {
+  const metaDescription = description || siteMetadata.description
+  const defaultTitle = siteMetadata.title
+
+  return {
+    defaultTitle,
+    lang,
+    meta: [
+      {
+        name: "description",
+        content: metaDescription,
+      },
+      {
+        name: "image",
+        content: image,
+      },
+      {
+        property: "og:title",
+        content: title,
+      },
+      {
+        property: "og:description",
+        content: metaDescription,
+      },
+      {
+        property: "og:type",
+        content: "website",
+      },
+      {
+        property: "og:image",
+        content: image,
+      },
+      {
+        name: "twitter:card",
+        content: "summary_large_image",
+      },
+      {
+        name: "twitter:creator",
+        content: siteMetadata.author.twitter,
+      },
+      {
+        name: "twitter:title",
+        content: title,
+      },
+      {
+        name: "twitter:description",
+        content: metaDescription,
+      },
+      ...meta,
+    ],
+    title,
+    titleTemplate: defaultTitle ? `%s | ${defaultTitle}` : undefined,
+  }
+}


### PR DESCRIPTION
## Summary
- Add a framework-neutral SEO metadata builder in `src/lib/seo.ts`
- Keep the Gatsby `SEO` component as a thin react-helmet adapter
- Narrow the meta prop shape away from DOM `HTMLMetaElement` toward serializable head metadata

## Verification
- `nix develop --command npm run lint`
- `nix develop --command npx tsc --noEmit`
- `nix develop --command npm run check:content`
- `nix develop --command npm run build`
- `nix develop --command npm run check:routes`
- `nix develop --command npm audit --json`
- `nix flake check`
- `git diff --check`