### PR TITLE
refactor: centralize route paths

### DIFF
--- a/src/components/atoms/Tags.tsx
+++ b/src/components/atoms/Tags.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { blogTagPath } from "../../lib/routes"
 
 type Props = {
   tags: Array<string>
@@ -9,7 +10,7 @@ const Tags: React.FC<Props> = ({ tags }) => (
     Tags:&nbsp;
     {tags.map((tag, index) => (
       <React.Fragment key={tag}>
-        <a className="text-indigo-600" href={`/blog/tag/${tag}`}>
+        <a className="text-indigo-600" href={blogTagPath(tag)}>
           {tag}
         </a>
         {index !== tags.length - 1 && " "}

--- a/src/components/molecules/Card.tsx
+++ b/src/components/molecules/Card.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import Image from "../atoms/Image"
 import ReadingTime from "../atoms/ReadingTime"
 import Date from "../atoms/Date"
+import { blogAuthorPath, blogPostPath, blogTagPath } from "../../lib/routes"
 import type { BlogPost } from "../../types/content"
 
 type Props = {
@@ -26,12 +27,12 @@ const Card: React.FC<Props> = ({ post }) => (
       <div className="flex-1">
         {post.tags?.map(tag => (
           <p className="text-sm font-medium text-indigo-600" key={tag}>
-            <a href={`/blog/tag/${tag}`} className="hover:underline">
+            <a href={blogTagPath(tag)} className="hover:underline">
               {tag}
             </a>
           </p>
         ))}
-        <a href={`/blog/post/${post.slug}`} className="mt-2 block">
+        <a href={blogPostPath(post)} className="mt-2 block">
           <p className="text-xl font-semibold text-gray-900">{post.title}</p>
           <p className="mt-3 text-base text-gray-500">{post.description}</p>
         </a>
@@ -39,7 +40,7 @@ const Card: React.FC<Props> = ({ post }) => (
       <div className="mt-6 flex items-center">
         {post.authors?.map(author => (
           <div className="shrink-0" key={author?.name}>
-            <a href={`/blog/author/${author?.identity}`}>
+            <a href={blogAuthorPath(author)}>
               <span className="sr-only">{author?.name}</span>
               {author?.picture && (
                 <Image
@@ -55,7 +56,7 @@ const Card: React.FC<Props> = ({ post }) => (
           <p className="text-sm font-medium text-gray-900">
             {post.authors?.map(author => (
               <a
-                href={`/blog/author/${author?.identity}`}
+                href={blogAuthorPath(author)}
                 className="hover:underline"
                 key={author?.name}
               >

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,12 +1,13 @@
 import React from "react"
 import Logo from "../atoms/Logo"
 import Links from "../molecules/Navigation/Links"
+import { blogIndexPath, pagePathBySlug } from "../../lib/routes"
 // import SingInSignUp from "../molecules/SignInSignUp"
 
 const navigation: Incipe.Links = [
-  { name: "Blog", href: "/blog" },
-  { name: "About", href: "/about" },
-  { name: "Environments", href: "/environments" },
+  { name: "Blog", href: blogIndexPath },
+  { name: "About", href: pagePathBySlug("about") },
+  { name: "Environments", href: pagePathBySlug("environments") },
   // { name: "Laboratory", href: "/laboratory" },
 ]
 

--- a/src/lib/routeData.ts
+++ b/src/lib/routeData.ts
@@ -1,4 +1,12 @@
 import { blogCaption, uniqueAuthors, uniqueTags } from "./content"
+import {
+  blogAuthorPathByIdentity,
+  blogIndexPath,
+  blogPostPath,
+  blogTagPath,
+  pagePath,
+  requireRouteSegment,
+} from "./routes"
 import type { BlogPost, BlogPostPreview, PageContent } from "../types/content"
 
 export type BlogPostRouteData = {
@@ -44,16 +52,6 @@ export const buildSiteRouteData = ({
   pages: buildPageRouteData(pages),
 })
 
-export const blogPostPath = (post: BlogPost) =>
-  `/blog/post/${requireString("blog post slug", post.slug)}/`
-
-export const blogTagPath = (tag: string) => `/blog/tag/${tag}/`
-
-export const blogAuthorPath = (authorId: string) => `/blog/author/${authorId}/`
-
-export const pagePath = (page: PageContent) =>
-  `/${requireString("page slug", page.slug)}/`
-
 const buildBlogPostRouteData = (
   posts: Array<BlogPost>,
 ): Array<BlogPostRouteData> =>
@@ -67,7 +65,7 @@ const buildBlogPostRouteData = (
 const buildBlogIndexRouteData = (
   posts: Array<BlogPost>,
 ): BlogPostsRouteData => ({
-  path: "/blog/",
+  path: blogIndexPath,
   title: "Blog",
   caption: blogCaption,
   posts,
@@ -87,10 +85,10 @@ const buildBlogAuthorRouteData = (
   posts: Array<BlogPost>,
 ): Array<BlogPostsRouteData> =>
   uniqueAuthors(posts).map(author => {
-    const authorId = requireString("author identity", author.identity)
+    const authorId = requireRouteSegment("author identity", author.identity)
 
     return {
-      path: blogAuthorPath(authorId),
+      path: blogAuthorPathByIdentity(authorId),
       title: `Author: ${author.name}`,
       caption: author.profile ?? undefined,
       authorId,
@@ -105,8 +103,3 @@ const buildPageRouteData = (pages: Array<PageContent>): Array<PageRouteData> =>
     path: pagePath(page),
     page,
   }))
-
-const requireString = (name: string, value: string | null | undefined) => {
-  if (typeof value === "string" && value.trim().length > 0) return value
-  throw new Error(`${name} must be a non-empty string.`)
-}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,34 @@
+import type { BlogPost, ContentAuthor, PageContent } from "../types/content"
+
+export const rootPath = "/"
+
+export const blogIndexPath = "/blog/"
+
+export const blogPostPath = (post: Pick<BlogPost, "slug">) =>
+  blogPostPathBySlug(post.slug)
+
+export const blogPostPathBySlug = (slug: string | null | undefined) =>
+  `/blog/post/${requireRouteSegment("blog post slug", slug)}/`
+
+export const blogTagPath = (tag: string) =>
+  `/blog/tag/${requireRouteSegment("blog tag", tag)}/`
+
+export const blogAuthorPath = (author: Pick<ContentAuthor, "identity">) =>
+  blogAuthorPathByIdentity(author.identity)
+
+export const blogAuthorPathByIdentity = (identity: string | null | undefined) =>
+  `/blog/author/${requireRouteSegment("author identity", identity)}/`
+
+export const pagePath = (page: Pick<PageContent, "slug">) =>
+  pagePathBySlug(page.slug)
+
+export const pagePathBySlug = (slug: string | null | undefined) =>
+  `/${requireRouteSegment("page slug", slug)}/`
+
+export const requireRouteSegment = (
+  name: string,
+  value: string | null | undefined,
+) => {
+  if (typeof value === "string" && value.trim().length > 0) return value
+  throw new Error(`${name} must be a non-empty string.`)
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,11 @@
 import { navigate } from "gatsby"
 import React, { useEffect } from "react"
+import { blogIndexPath } from "../lib/routes"
 import IndexView from "../views/IndexView"
 
 const Index: React.FC = () => {
   useEffect(() => {
-    navigate("/blog/")
+    navigate(blogIndexPath)
   }, [])
 
   return <IndexView />

--- a/src/views/BlogPostView.tsx
+++ b/src/views/BlogPostView.tsx
@@ -6,6 +6,7 @@ import Hero from "../components/molecules/Hero"
 import StyledMDXComponent from "../components/StyledMDXComponent"
 import DummyText from "../constants/Dummy/Text"
 import Date from "../components/atoms/Date"
+import { blogPostPath } from "../lib/routes"
 import type { BlogPost, BlogPostPreview } from "../types/content"
 
 export type BlogPostViewProps = {
@@ -62,7 +63,7 @@ const BlogPostView: React.FC<BlogPostViewProps> = ({
                 <li className="p-0">
                   <a
                     className="float-left"
-                    href={`/blog/post/${previous.slug}`}
+                    href={blogPostPath(previous)}
                     rel="prev"
                   >
                     ← {previous.title}
@@ -73,7 +74,7 @@ const BlogPostView: React.FC<BlogPostViewProps> = ({
                 <li className="p-0">
                   <a
                     className="float-right"
-                    href={`/blog/post/${next.slug}`}
+                    href={blogPostPath(next)}
                     rel="next"
                   >
                     {next.title} →


### PR DESCRIPTION
## Summary
- Add Gatsby-independent route path helpers in `src/lib/routes.ts`
- Reuse the same helpers from route data generation and internal UI links
- Keep generated route contract unchanged while normalizing internal links to canonical trailing-slash routes

## Verification
- `nix develop --command npm run lint`
- `nix develop --command npx tsc --noEmit`
- `nix develop --command npm run check:content`
- `nix develop --command npm run build`
- `nix develop --command npm run check:routes`
- `nix develop --command npm audit --json`
- `nix flake check`
- `git diff --check`