### PR TITLE
Publish Astro output to Cloudflare Pages

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -27,9 +27,12 @@ jobs:
           nix develop -c npm run check:content
           nix develop -c npm run build
           nix develop -c npm run check:routes
+          nix develop -c npm run build:astro
+          nix develop -c npm run check:routes -- --output-dir output/astro
+          nix develop -c npm run check:astro-render
       - name: Publish
         uses: cloudflare/wrangler-action@v3
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: pages deploy --project-name=incipe-dev public
+          command: pages deploy --project-name=incipe-dev output/astro


### PR DESCRIPTION
## Summary
- keep the Gatsby build and route contract as the comparison baseline in the deployment workflow
- build Astro during deployment and validate Astro routes plus Gatsby/Astro render parity before publishing
- publish Cloudflare Pages from output/astro instead of public

## Verification
- nix develop --command npx prettier --check .github/workflows/pages-deployment.yaml
- git diff --check
- nix develop --command npm run check:content
- nix develop --command npm run clean
- nix develop --command npm run build
- nix develop --command npm run check:routes
- nix develop --command npm run build:astro
- nix develop --command npm run check:routes -- --output-dir output/astro
- nix develop --command npm run check:astro-render
- nix develop --command npm run lint
- nix develop --command npx tsc --noEmit
- nix develop --command npm audit --json
- nix flake check