### PR TITLE
Update GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Nix
         uses: cachix/install-nix-action@v27
         with:
@@ -31,7 +31,7 @@ jobs:
           nix develop -c npm run check:routes -- --output-dir output/astro
           nix develop -c npm run check:astro-render
       - name: Publish
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27
@@ -55,7 +55,7 @@ jobs:
       GOOGLE_TAGMANAGER_PREVIEW: ${{ secrets.GOOGLE_TAGMANAGER_PREVIEW }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27


### PR DESCRIPTION
## Summary
- update actions/checkout from v4 to v6 in PR and deployment workflows
- update cloudflare/wrangler-action from v3 to v4 for Cloudflare Pages deployment
- keep workflow commands and permissions unchanged

## Verification
- nix develop --command npx prettier --check .github/workflows/pages-deployment.yaml .github/workflows/pr-build.yaml
- git diff --check
- nix flake check

Note: actionlint is not available in the current Nix dev shell.