### PR TITLE
Restore Astro static SEO artifacts

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -29,6 +29,7 @@ jobs:
           nix develop -c npm run check:routes
           nix develop -c npm run build:astro
           nix develop -c npm run check:routes -- --output-dir output/astro
+          nix develop -c npm run check:static-artifacts
           nix develop -c npm run check:astro-render
       - name: Publish
         uses: cloudflare/wrangler-action@v4

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -81,5 +81,8 @@ jobs:
       - name: Check Astro route contract
         run: nix develop -c npm run check:routes -- --output-dir output/astro
 
+      - name: Check static artifacts
+        run: nix develop -c npm run check:static-artifacts
+
       - name: Check Astro render parity
         run: nix develop -c npm run check:astro-render

--- a/astro/lib/staticArtifacts.ts
+++ b/astro/lib/staticArtifacts.ts
@@ -1,0 +1,65 @@
+import { siteMetadata } from "../../src/config/siteMetadata"
+import { rootPath } from "../../src/lib/routes"
+import { loadSiteRouteData } from "./siteRouteData"
+
+export const robotsPath = "/robots.txt"
+export const sitemapIndexPath = "/sitemap-index.xml"
+export const sitemapPath = "/sitemap-0.xml"
+
+export const renderRobotsTxt = () =>
+  [
+    "User-agent: *",
+    "Allow: /",
+    `Sitemap: ${absoluteUrl(sitemapIndexPath)}`,
+    `Host: ${siteMetadata.siteUrl}`,
+    "",
+  ].join("\n")
+
+export const renderSitemapIndexXml = () =>
+  [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    "<sitemap>",
+    `<loc>${escapeXml(absoluteUrl(sitemapPath))}</loc>`,
+    "</sitemap>",
+    "</sitemapindex>",
+  ].join("")
+
+export const renderSitemapXml = () => {
+  const urls = loadSitemapRoutes().map(route => absoluteUrl(route))
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    [
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
+      ' xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"',
+      ' xmlns:xhtml="http://www.w3.org/1999/xhtml"',
+      ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"',
+      ' xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">',
+    ].join(""),
+    ...urls.map(url => `<url><loc>${escapeXml(url)}</loc></url>`),
+    "</urlset>",
+  ].join("")
+}
+
+export const loadSitemapRoutes = () => {
+  const routeData = loadSiteRouteData()
+
+  return [
+    ...routeData.blogPosts.map(route => route.path),
+    ...routeData.blogPostIndexes.map(route => route.path),
+    ...routeData.pages.map(route => route.path),
+    rootPath,
+  ]
+}
+
+const absoluteUrl = (pathname: string) =>
+  new URL(pathname, `${siteMetadata.siteUrl}/`).href
+
+const escapeXml = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;")

--- a/astro/pages/robots.txt.ts
+++ b/astro/pages/robots.txt.ts
@@ -1,0 +1,8 @@
+import { renderRobotsTxt } from "../lib/staticArtifacts"
+
+export const GET = () =>
+  new Response(renderRobotsTxt(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  })

--- a/astro/pages/sitemap-0.xml.ts
+++ b/astro/pages/sitemap-0.xml.ts
@@ -1,0 +1,8 @@
+import { renderSitemapXml } from "../lib/staticArtifacts"
+
+export const GET = () =>
+  new Response(renderSitemapXml(), {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+    },
+  })

--- a/astro/pages/sitemap-index.xml.ts
+++ b/astro/pages/sitemap-index.xml.ts
@@ -1,0 +1,8 @@
+import { renderSitemapIndexXml } from "../lib/staticArtifacts"
+
+export const GET = () =>
+  new Response(renderSitemapIndexXml(), {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+    },
+  })

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "check:content": "node scripts/check-content.mjs",
     "check:astro-render": "node scripts/check-astro-render-parity.mjs",
     "check:routes": "node scripts/check-routes.mjs",
+    "check:static-artifacts": "node scripts/check-static-artifacts.mjs",
     "develop": "gatsby develop",
     "develop:astro": "astro dev --config astro.config.mjs",
     "export:contentful": "node scripts/export-contentful-mdx.mjs",

--- a/scripts/check-static-artifacts.mjs
+++ b/scripts/check-static-artifacts.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const projectRoot = path.resolve(scriptDir, "..")
+const defaultOutputDir =
+  process.env["STATIC_ARTIFACTS_OUTPUT_DIR"] ?? "output/astro"
+const siteUrl = process.env["SITE_URL"] ?? "https://incipe.dev"
+const sitemapIndexPath = "/sitemap-index.xml"
+const sitemapPath = "/sitemap-0.xml"
+const robotsPath = "/robots.txt"
+
+const main = async () => {
+  const options = parseArguments(process.argv.slice(2))
+  const outputRoot = path.resolve(
+    projectRoot,
+    options.outputDir ?? defaultOutputDir,
+  )
+  const artifacts = await readArtifacts(outputRoot)
+  const errors = [
+    ...artifacts.errors,
+    ...validateRobotsTxt(artifacts.files.get(robotsPath) ?? ""),
+    ...validateSitemapIndex(artifacts.files.get(sitemapIndexPath) ?? ""),
+    ...validateSitemap(artifacts.files.get(sitemapPath) ?? ""),
+  ]
+
+  if (errors.length > 0) {
+    printErrors(errors)
+    return
+  }
+
+  console.log("Static artifacts are valid.")
+}
+
+const parseArguments = args => {
+  const options = {
+    outputDir: undefined,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+
+    if (argument === "--output-dir") {
+      options.outputDir = args[index + 1]
+      if (!options.outputDir || options.outputDir.startsWith("--")) {
+        throw new Error("--output-dir requires a value")
+      }
+      index += 1
+      continue
+    }
+
+    if (argument?.startsWith("--output-dir=")) {
+      options.outputDir = argument.slice("--output-dir=".length)
+      if (!options.outputDir) {
+        throw new Error("--output-dir requires a value")
+      }
+      continue
+    }
+
+    throw new Error(`Unknown argument: ${argument}`)
+  }
+
+  return options
+}
+
+const readArtifacts = async outputRoot => {
+  const files = new Map()
+  const errors = []
+
+  await Promise.all(
+    [robotsPath, sitemapIndexPath, sitemapPath].map(async artifactPath => {
+      const filePath = path.join(outputRoot, artifactPath)
+
+      try {
+        files.set(artifactPath, await readFile(filePath, "utf8"))
+      } catch (error) {
+        errors.push(
+          `Missing static artifact ${artifactPath}: ${path.relative(
+            projectRoot,
+            filePath,
+          )} (${error.message})`,
+        )
+      }
+    }),
+  )
+
+  return { errors, files }
+}
+
+const validateRobotsTxt = source => {
+  if (!source) return []
+
+  const expectedLines = [
+    "User-agent: *",
+    "Allow: /",
+    `Sitemap: ${absoluteUrl(sitemapIndexPath)}`,
+    `Host: ${siteUrl}`,
+  ]
+
+  return expectedLines
+    .filter(line => !source.split("\n").includes(line))
+    .map(line => `robots.txt is missing line: ${line}`)
+}
+
+const validateSitemapIndex = source => {
+  if (!source) return []
+
+  const locs = extractLocs(source)
+  const expectedLoc = absoluteUrl(sitemapPath)
+
+  if (locs.length === 1 && locs[0] === expectedLoc) return []
+
+  return [
+    `sitemap-index.xml must contain only ${expectedLoc}; found ${JSON.stringify(
+      locs,
+    )}`,
+  ]
+}
+
+const validateSitemap = source => {
+  if (!source) return []
+
+  const expectedUrls = listExpectedSitemapUrls()
+  const actualUrls = extractLocs(source)
+  const errors = []
+
+  if (actualUrls.includes(absoluteUrl("/404/"))) {
+    errors.push("sitemap-0.xml must not include /404/")
+  }
+
+  if (actualUrls.includes(absoluteUrl("/404.html"))) {
+    errors.push("sitemap-0.xml must not include /404.html")
+  }
+
+  const missingUrls = difference(expectedUrls, actualUrls)
+  const extraUrls = difference(actualUrls, expectedUrls)
+
+  if (missingUrls.length > 0) {
+    errors.push(
+      `sitemap-0.xml is missing URLs: ${JSON.stringify(missingUrls.slice(0, 10))}`,
+    )
+  }
+
+  if (extraUrls.length > 0) {
+    errors.push(
+      `sitemap-0.xml has unexpected URLs: ${JSON.stringify(extraUrls.slice(0, 10))}`,
+    )
+  }
+
+  return errors
+}
+
+const listExpectedSitemapUrls = () =>
+  execFileSync(
+    process.execPath,
+    [path.join(scriptDir, "check-routes.mjs"), "--list"],
+    {
+      encoding: "utf8",
+    },
+  )
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .filter(route => route !== "/404/" && route !== "/404.html")
+    .map(route => absoluteUrl(route))
+    .sort()
+
+const extractLocs = source =>
+  Array.from(source.matchAll(/<loc>(?<loc>[\s\S]*?)<\/loc>/gu))
+    .map(match => unescapeXml(match.groups?.["loc"] ?? "").trim())
+    .sort()
+
+const absoluteUrl = pathname => new URL(pathname, `${siteUrl}/`).href
+
+const unescapeXml = value =>
+  value
+    .replaceAll("&apos;", "'")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&gt;", ">")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&amp;", "&")
+
+const difference = (left, right) => {
+  const remaining = new Map()
+
+  for (const value of right) {
+    remaining.set(value, (remaining.get(value) ?? 0) + 1)
+  }
+
+  return left.filter(value => {
+    const count = remaining.get(value) ?? 0
+
+    if (count <= 0) return true
+
+    remaining.set(value, count - 1)
+    return false
+  })
+}
+
+const printErrors = errors => {
+  console.error(errors.map(error => `- ${error}`).join("\n"))
+  process.exitCode = 1
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- generate robots.txt, sitemap-index.xml, and sitemap-0.xml from Astro static endpoints
- add a static artifact checker that validates robots.txt, sitemap index, sitemap URL set, and excludes 404 routes
- run the new check in PR CI and the Cloudflare Pages deployment workflow before publishing

## Verification
- nix develop --command npm run clean
- nix develop --command npm run build
- nix develop --command npm run check:routes
- nix develop --command npm run build:astro
- nix develop --command npm run check:routes -- --output-dir output/astro
- nix develop --command npm run check:static-artifacts
- nix develop --command npm run check:static-artifacts -- --output-dir public
- nix develop --command npm run check:astro-render
- Gatsby/Astro sitemap URL set comparison: 64 URLs each, same=true
- nix develop --command npx prettier --check astro/lib/staticArtifacts.ts astro/pages/robots.txt.ts astro/pages/sitemap-0.xml.ts astro/pages/sitemap-index.xml.ts scripts/check-static-artifacts.mjs package.json .github/workflows/pr-build.yaml .github/workflows/pages-deployment.yaml
- nix develop --command npm run lint
- nix develop --command npx tsc --noEmit
- nix develop --command npm run check:content
- nix develop --command npm audit --json
- nix flake check
- git diff --check