### PR TITLE
Use npm ci in Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -23,7 +23,7 @@ jobs:
           GOOGLE_TAGMANAGER_AUTH: ${{ secrets.GOOGLE_TAGMANAGER_AUTH }}
           GOOGLE_TAGMANAGER_PREVIEW: ${{ secrets.GOOGLE_TAGMANAGER_PREVIEW }}
         run: |
-          nix develop -c npm install --legacy-peer-deps
+          nix develop -c npm ci --legacy-peer-deps
           nix develop -c npm run check:content
           nix develop -c npm run build
           nix develop -c npm run check:routes


### PR DESCRIPTION
## Summary
- replace npm install with npm ci in the Cloudflare Pages deployment build
- keep --legacy-peer-deps to match the PR build workflow
- make deployment installs lockfile-based and consistent with CI

## Verification
- nix develop --command npx prettier --check .github/workflows/pages-deployment.yaml
- git diff --check
- nix flake check
- nix develop --command npm ci --legacy-peer-deps
- nix develop --command npm run check:content
- nix develop --command npm run lint
- nix develop --command npx tsc --noEmit
- nix develop --command npm audit --json