### PR TITLE
Remove Gatsby baseline from Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -25,12 +25,9 @@ jobs:
         run: |
           nix develop -c npm ci --legacy-peer-deps
           nix develop -c npm run check:content
-          nix develop -c npm run build
-          nix develop -c npm run check:routes
           nix develop -c npm run build:astro
           nix develop -c npm run check:routes -- --output-dir output/astro
           nix develop -c npm run check:static-artifacts
-          nix develop -c npm run check:astro-render
       - name: Publish
         uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
## Summary
- remove Gatsby build and Gatsby route contract from the Cloudflare Pages deployment workflow
- remove Gatsby/Astro render parity from deployment, since publishing now uses Astro output only
- keep Astro build, Astro route contract, static artifact check, publish, and deployed-site smoke check in deployment
- keep Gatsby baseline and render parity in PR CI for now

## Verification
- nix develop --command npx prettier --check .github/workflows/pages-deployment.yaml
- git diff --check
- nix flake check
- nix develop --command npm run clean
- nix develop --command npm run check:content
- nix develop --command npm run build:astro
- nix develop --command npm run check:routes -- --output-dir output/astro
- nix develop --command npm run check:static-artifacts
- nix develop --command npm run lint
- nix develop --command npx tsc --noEmit
- nix develop --command npm audit --json