### PR TITLE
ci: drop pr gatsby baseline

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -69,12 +69,6 @@ jobs:
       - name: Check content files
         run: nix develop -c npm run check:content
 
-      - name: Build site
-        run: nix develop -c npm run build
-
-      - name: Check route contract
-        run: nix develop -c npm run check:routes
-
       - name: Build Astro site
         run: nix develop -c npm run build:astro
 
@@ -86,6 +80,3 @@ jobs:
 
       - name: Check static artifacts
         run: nix develop -c npm run check:static-artifacts
-
-      - name: Check Astro render parity
-        run: nix develop -c npm run check:astro-render


### PR DESCRIPTION
## Summary
- remove the Gatsby production build step from PR CI
- remove the Gatsby route contract check from PR CI
- remove the Astro/Gatsby render parity check from PR CI now that Astro route, static artifact, and head metadata checks cover the deployed output

## Verification
- nix develop --command npm run clean
- nix develop --command npm run build:astro
- nix develop --command npm run check:content
- nix develop --command npm run check:routes -- --output-dir output/astro
- nix develop --command npm run check:astro-head
- nix develop --command npm run check:static-artifacts
- nix flake check
- nix develop --command npx prettier --check .github/workflows/pr-build.yaml
- git diff --check