### PR TITLE
ci: set up pnpm for pages publish

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -29,6 +29,11 @@ jobs:
           nix develop -c pnpm run check:routes --output-dir output/astro
           nix develop -c pnpm run check:astro-head
           nix develop -c pnpm run check:static-artifacts
+      - name: Set up pnpm for Wrangler Action
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.0
+          run_install: false
       - name: Publish
         uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
## Summary
- add `pnpm/action-setup@v4` before `cloudflare/wrangler-action@v4` in the Pages deployment workflow
- keep the build itself on `nix develop -c pnpm ...`; this only exposes pnpm to the GitHub Action runner for Wrangler Action's package-manager detection

## Context
The main deploy for `deps: switch package manager to pnpm` built successfully, then failed in the Publish step because `wrangler-action` detected pnpm from the lockfile but could not find `pnpm` on the runner PATH.

## Verification
- `nix develop --command pnpm exec prettier --check .github/workflows/pages-deployment.yaml`
- `git diff --check`
