### PR TITLE
ci: use nix pnpm for pages publish

### DIFF
--- a/.github/workflows/pages-deployment.yaml
+++ b/.github/workflows/pages-deployment.yaml
@@ -29,11 +29,9 @@ jobs:
           nix develop -c pnpm run check:routes --output-dir output/astro
           nix develop -c pnpm run check:astro-head
           nix develop -c pnpm run check:static-artifacts
-      - name: Set up pnpm for Wrangler Action
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.28.0
-          run_install: false
+      - name: Add pnpm to PATH for Wrangler Action
+        run: |
+          nix develop -c bash -lc 'printf "%s\n" "$(dirname "$(command -v pnpm)")" >> "$GITHUB_PATH"'
       - name: Publish
         uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
## Summary
- replace `pnpm/action-setup@v4` with a shell step that adds the Nix dev shell pnpm binary directory to `$GITHUB_PATH`
- keep Wrangler Action able to install/run with pnpm without introducing the Node.js 20 action deprecation warning from `pnpm/action-setup@v4`

## Verification
- `GITHUB_PATH=$(mktemp) nix develop -c bash -lc 'printf "%s\\n" "$(dirname "$(command -v pnpm)")" >> "$GITHUB_PATH"'`
- `nix develop --command pnpm exec prettier --check .github/workflows/pages-deployment.yaml`
- `git diff --check`
