### PR TITLE
ci: strengthen lint and type checks

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -69,6 +69,12 @@ jobs:
       - name: Run unit tests
         run: nix develop -c pnpm run test
 
+      - name: Run lint
+        run: nix develop -c pnpm run lint
+
+      - name: Run typecheck
+        run: nix develop -c pnpm run typecheck
+
       - name: Check content files
         run: nix develop -c pnpm run check:content
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,15 +3,36 @@ import typescript from "typescript-eslint"
 import typescriptParser from "@typescript-eslint/parser"
 import prettier from "eslint-config-prettier"
 import globals from "globals"
+import importPlugin from "eslint-plugin-import"
+import jsxA11y from "eslint-plugin-jsx-a11y"
 import react from "eslint-plugin-react"
+import reactHooks from "eslint-plugin-react-hooks"
 import tailwindcss from "eslint-plugin-tailwindcss"
 
+const tsconfigRootDir = new URL(".", import.meta.url).pathname
+
 export default [
+  {
+    ignores: [
+      ".astro/",
+      ".cache/",
+      ".spago/",
+      "node_modules/",
+      "output/",
+      "public/",
+    ],
+  },
   js.configs.recommended,
   typescript.configs.eslintRecommended,
   ...typescript.configs.strict,
-  prettier,
+  importPlugin.flatConfigs.recommended,
+  importPlugin.flatConfigs.typescript,
+  react.configs.flat.recommended,
+  react.configs.flat["jsx-runtime"],
+  jsxA11y.flatConfigs.recommended,
+  ...tailwindcss.configs["flat/recommended"],
   {
+    files: ["**/*.{js,mjs,ts,tsx}"],
     languageOptions: {
       globals: {
         ...globals.browser,
@@ -22,16 +43,16 @@ export default [
           jsx: true,
         },
         project: "./tsconfig.eslint.json",
+        tsconfigRootDir,
       },
     },
     plugins: {
-      react: react,
-      typescript: typescript,
-      tailwindcss: tailwindcss,
+      "react-hooks": reactHooks,
     },
     rules: {
-      ...react.configs.recommended.rules,
-      ...typescript.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "import/no-unresolved": "off",
+      "tailwindcss/enforces-shorthand": "off",
     },
     settings: {
       react: {
@@ -40,7 +61,21 @@ export default [
     },
   },
   {
-    files: ["scripts/**/*.mjs"],
+    files: ["src/components/StyledMDXComponent.tsx"],
+    rules: {
+      "jsx-a11y/heading-has-content": "off",
+    },
+  },
+  {
+    files: [
+      "*.config.{js,mjs,ts}",
+      "astro.config.mjs",
+      "eslint.config.mjs",
+      "postcss.config.js",
+      "tailwind.config.mjs",
+      "vitest.config.ts",
+      "scripts/**/*.mjs",
+    ],
     languageOptions: {
       globals: {
         ...globals.node,
@@ -60,13 +95,5 @@ export default [
       "@typescript-eslint/no-shadow": ["off"],
     },
   },
-  {
-    files: ["postcss.config.js"],
-    languageOptions: {
-      sourceType: "commonjs",
-    },
-  },
-  {
-    ignores: [".astro/", ".cache/", ".spago/", "public/", "output/"],
-  },
+  prettier,
 ]

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.28.0",
+    "@eslint/js": "^9.39.4",
     "@types/mdx": "^2.0.13",
     "@types/node": "^24.0.14",
     "@types/react": "^18.3.23",
@@ -84,6 +85,7 @@
     "clean": "rm -rf .astro .cache public output",
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint ."
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       "@babel/plugin-proposal-decorators":
         specifier: ^7.28.0
         version: 7.29.7(@babel/core@7.29.7)
+      "@eslint/js":
+        specifier: ^9.39.4
+        version: 9.39.4
       "@types/mdx":
         specifier: ^2.0.13
         version: 2.0.14


### PR DESCRIPTION
## Summary
- wire the existing ESLint plugin dependencies into the flat config for React JSX runtime, React Hooks, jsx-a11y, import, and Tailwind checks
- keep `import/no-unresolved` disabled because TypeScript handles module resolution in CI via typecheck
- keep the MDX heading wrapper exemption for `StyledMDXComponent`, where content is supplied by MDX at runtime
- add a `typecheck` script and run both `pnpm run lint` and `pnpm run typecheck` in PR Build

## Verification
- `nix develop --command pnpm run lint`
- `nix develop --command pnpm run typecheck`
- `nix develop --command pnpm run test`
- `nix develop --command pnpm exec prettier --check eslint.config.mjs package.json .github/workflows/pr-build.yaml`
- `nix develop --command pnpm install --frozen-lockfile --ignore-scripts`
- `nix develop --command pnpm install --frozen-lockfile`
- `nix flake check`
- `nix develop --command pnpm audit --json`
- `nix develop --command pnpm run clean`
- `nix develop --command pnpm run build`
- `nix develop --command pnpm run check:content`
- `nix develop --command pnpm run check:routes --output-dir output/astro`
- `nix develop --command pnpm run check:astro-head`
- `nix develop --command pnpm run check:static-artifacts`
- `git diff --check`
