### PR TITLE
ci: add formatting checks

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -66,6 +66,9 @@ jobs:
       - name: Install pnpm dependencies
         run: nix develop -c pnpm install --frozen-lockfile
 
+      - name: Check formatting
+        run: nix develop -c pnpm run format:check
+
       - name: Run unit tests
         run: nix develop -c pnpm run test
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,8 @@
 .cache
+.claude
 .direnv
 .spago
+CLAUDE.md
 output
 public
 package.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,11 @@ export default [
       "public/",
     ],
   },
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+    },
+  },
   js.configs.recommended,
   typescript.configs.eslintRecommended,
   ...typescript.configs.strict,

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "export:contentful": "node scripts/export-contentful-mdx.mjs",
     "localize:content-assets": "node scripts/localize-content-assets.mjs",
     "format": "pnpm run format:eslint && pnpm run format:prettier",
-    "format:prettier": "prettier --write \"**/*.{js,jsx,mjs,ts,tsx,json,md}\"",
+    "format:prettier": "prettier --write \"**/*.{js,jsx,mjs,ts,tsx,json,md,yml,yaml}\" \".github/**/*.{yml,yaml}\"",
+    "format:check": "prettier --check \"**/*.{js,jsx,mjs,ts,tsx,json,md,yml,yaml}\" \".github/**/*.{yml,yaml}\"",
     "format:eslint": "eslint --fix \"**/*.{js,jsx,mjs,ts,tsx}\"",
     "start": "astro dev --config astro.config.mjs",
     "serve": "astro preview --config astro.config.mjs",
@@ -86,7 +87,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint . --max-warnings=0"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -13,10 +13,7 @@ const contentfulAssetPattern = /(?:https:)?\/\/images\.ctfassets\.net\//u
 const markdownImagePattern = /!\[[^\]]*\]\((?<url>[^)\s]+)(?:\s+"[^"]*")?\)/gu
 
 const main = async () => {
-  const errors = [
-    ...(await validateBlogPosts()),
-    ...(await validatePages()),
-  ]
+  const errors = [...(await validateBlogPosts()), ...(await validatePages())]
 
   if (errors.length > 0) {
     console.error(errors.map(error => `- ${error}`).join("\n"))
@@ -101,8 +98,9 @@ const readMdxCollection = async collection => {
 }
 
 const parseMdxDocument = source => {
-  const match =
-    /^---\n(?<frontmatter>[\s\S]*?)\n---\n?(?<body>[\s\S]*)$/u.exec(source)
+  const match = /^---\n(?<frontmatter>[\s\S]*?)\n---\n?(?<body>[\s\S]*)$/u.exec(
+    source,
+  )
 
   if (!match?.groups) {
     return {
@@ -208,7 +206,9 @@ const validateRequiredString = (collection, document, key) => {
   const value = document.frontmatter[key]
   if (typeof value === "string" && value.trim().length > 0) return []
 
-  return [`${collection}/${document.fileName}: ${key} must be a non-empty string`]
+  return [
+    `${collection}/${document.fileName}: ${key} must be a non-empty string`,
+  ]
 }
 
 const validatePublishedOn = (collection, document) => {
@@ -279,7 +279,9 @@ const validateAuthors = document => {
 
 const validateObjectString = (collection, document, key, value) => {
   if (typeof value === "string" && value.trim().length > 0) return []
-  return [`${collection}/${document.fileName}: ${key} must be a non-empty string`]
+  return [
+    `${collection}/${document.fileName}: ${key} must be a non-empty string`,
+  ]
 }
 
 const validateImage = (collection, document, key, value) => {

--- a/src/components/molecules/Hero.tsx
+++ b/src/components/molecules/Hero.tsx
@@ -11,11 +11,7 @@ type Props = {
 const Hero: React.FC<Props> = ({ image, title, content }) => (
   <div>
     {image && (
-      <Image
-        alt={title}
-        image={image}
-        className="h-96 w-full object-cover"
-      />
+      <Image alt={title} image={image} className="h-96 w-full object-cover" />
     )}
     <div className="pt-10">
       <h1 className="border-b border-slate-500 pb-4 text-2xl text-slate-700">

--- a/src/constants/CreativeCommons/BYNC.tsx
+++ b/src/constants/CreativeCommons/BYNC.tsx
@@ -5,7 +5,7 @@ const BYNC: Incipe.CreativeCommons.License = {
   abbreviation: "BY-NC",
   deed: new URL("https://creativecommons.org/licenses/by-nc/4.0/"),
   leagalCode: new URL(
-    "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+    "https://creativecommons.org/licenses/by-nc/4.0/legalcode",
   ),
   button: BYNCButton,
   version: 4.0,

--- a/src/constants/CreativeCommons/BYNCND.tsx
+++ b/src/constants/CreativeCommons/BYNCND.tsx
@@ -5,7 +5,7 @@ const BYNCND: Incipe.CreativeCommons.License = {
   abbreviation: "BY-NC-ND",
   deed: new URL("https://creativecommons.org/licenses/by-nc-nd/4.0/"),
   leagalCode: new URL(
-    "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+    "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode",
   ),
   button: BYNCNDButton,
   version: 4.0,

--- a/src/constants/CreativeCommons/BYNCSA.tsx
+++ b/src/constants/CreativeCommons/BYNCSA.tsx
@@ -5,7 +5,7 @@ const BYNCSA: Incipe.CreativeCommons.License = {
   abbreviation: "BY-NC-SA",
   deed: new URL("https://creativecommons.org/licenses/by-nc-sa/4.0/"),
   leagalCode: new URL(
-    "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+    "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode",
   ),
   button: BYNCSAButton,
   version: 4.0,

--- a/src/constants/CreativeCommons/BYND.tsx
+++ b/src/constants/CreativeCommons/BYND.tsx
@@ -5,7 +5,7 @@ const BYND: Incipe.CreativeCommons.License = {
   abbreviation: "BY-ND",
   deed: new URL("https://creativecommons.org/licenses/by-nd/4.0/"),
   leagalCode: new URL(
-    "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+    "https://creativecommons.org/licenses/by-nd/4.0/legalcode",
   ),
   button: BYNDButton,
   version: 4.0,

--- a/src/constants/CreativeCommons/BYSA.tsx
+++ b/src/constants/CreativeCommons/BYSA.tsx
@@ -5,7 +5,7 @@ const BYSA: Incipe.CreativeCommons.License = {
   abbreviation: "BY-SA",
   deed: new URL("https://creativecommons.org/licenses/by-sa/4.0/"),
   leagalCode: new URL(
-    "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+    "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
   ),
   button: BYSAButton,
   version: 4.0,

--- a/src/hooks/useReadingTime.ts
+++ b/src/hooks/useReadingTime.ts
@@ -4,7 +4,7 @@ const getCharacterLength = (str: string) => [...str].length
 
 const useReadingTime = (markdownText: string, wordsPerMinute = 400) => {
   const charCount = getCharacterLength(
-    removeMd(markdownText).replaceAll(/\s/g, "")
+    removeMd(markdownText).replaceAll(/\s/g, ""),
   )
   return { minutes: Math.round(charCount / wordsPerMinute) }
 }


### PR DESCRIPTION
## Summary
- add a Prettier format check script and run it in PR Build
- include YAML files, including GitHub workflows, in Prettier formatting
- make ESLint fail on warnings and report unused disable directives as errors
- format existing files needed for the new check

## Verification
- nix develop --command pnpm run format:check
- nix develop --command pnpm run lint
- nix develop --command pnpm run typecheck
- nix develop --command pnpm run test
- nix flake check
- nix develop --command pnpm install --frozen-lockfile --ignore-scripts
- nix develop --command pnpm install --frozen-lockfile
- nix develop --command pnpm run check:content
- nix develop --command pnpm run build
- nix develop --command pnpm run check:routes --output-dir output/astro
- nix develop --command pnpm run check:astro-head
- nix develop --command pnpm run check:static-artifacts
- git diff --check