### PR TITLE
content: remove Contentful export metadata

### DIFF
--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -43,7 +43,7 @@ const validateBlogPosts = async () => {
       ...validateStringArray("blog", document, "tags"),
       ...validateAuthors(document),
       ...validateImage("blog", document, "heroImage", frontmatter["heroImage"]),
-      ...validateContentfulMetadata("blog", document),
+      ...validateNoContentfulFrontmatter("blog", document),
       ...validateBody("blog", document),
       ...(await validateMarkdownImages("blog", document)),
       ...validateNoContentfulAssetUrls("blog", document),
@@ -65,7 +65,7 @@ const validatePages = async () => {
       ...validateFileNameMatchesSlug("pages", document),
       ...validateRequiredString("pages", document, "title"),
       ...validateRequiredString("pages", document, "slug"),
-      ...validateContentfulMetadata("pages", document),
+      ...validateNoContentfulFrontmatter("pages", document),
       ...validateBody("pages", document),
       ...(await validateMarkdownImages("pages", document)),
       ...validateNoContentfulAssetUrls("pages", document),
@@ -313,39 +313,16 @@ const validateImage = (collection, document, key, value) => {
   return errors
 }
 
-const validateContentfulMetadata = (collection, document) => {
-  const metadata = document.frontmatter["contentful"]
-  if (metadata == null) return []
-
-  if (!isPlainObject(metadata)) {
-    return [`${collection}/${document.fileName}: contentful must be an object`]
-  }
-
-  return [
-    ...validateObjectString(
-      collection,
-      document,
-      "contentful.entryId",
-      metadata["entryId"],
-    ),
-    ...validateObjectString(
-      collection,
-      document,
-      "contentful.contentType",
-      metadata["contentType"],
-    ),
-    ...validateObjectString(
-      collection,
-      document,
-      "contentful.updatedAt",
-      metadata["updatedAt"],
-    ),
-  ]
-}
-
 const validateBody = (collection, document) => {
   if (document.body.trim().length > 0) return []
   return [`${collection}/${document.fileName}: body must be non-empty`]
+}
+
+const validateNoContentfulFrontmatter = (collection, document) => {
+  if (!Object.hasOwn(document.frontmatter, "contentful")) return []
+  return [
+    `${collection}/${document.fileName}: contentful export metadata is not part of local MDX content`,
+  ]
 }
 
 const validateMarkdownImages = async (collection, document) => {

--- a/src/content/blog/align-the-japanese-input-switch-shortcut-in-google-ime-for-windows-with-fcitx-mozc.mdx
+++ b/src/content/blog/align-the-japanese-input-switch-shortcut-in-google-ime-for-windows-with-fcitx-mozc.mdx
@@ -6,7 +6,6 @@ publishedOn: "2024-01-30"
 tags: ["windows","ime","japaniese","google"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"1Gh6apI7nbfft7uuoEjl9i","contentType":"post","updatedAt":"2024-05-19T23:52:38.628Z"}
 ---
 
 ## 導入

--- a/src/content/blog/deploy-to-cloudflare-pages.mdx
+++ b/src/content/blog/deploy-to-cloudflare-pages.mdx
@@ -6,7 +6,6 @@ publishedOn: "2022-06-01"
 tags: ["github actions","cloudflare pages","nix"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"4IzhemcxwguHtu6bCaHIKR","contentType":"post","updatedAt":"2022-07-20T11:50:59.852Z"}
 ---
 
 ## 導入

--- a/src/content/blog/disable-window-transparency-with-picom.mdx
+++ b/src/content/blog/disable-window-transparency-with-picom.mdx
@@ -6,7 +6,6 @@ publishedOn: "2023-07-27"
 tags: ["linux","picom"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"5rQwPCQ2o9ch3rnKMmHkmz","contentType":"post","updatedAt":"2023-08-07T04:43:41.588Z"}
 ---
 
 ## 導入

--- a/src/content/blog/setting-up-a-powershell-development-environment.mdx
+++ b/src/content/blog/setting-up-a-powershell-development-environment.mdx
@@ -6,7 +6,6 @@ publishedOn: "2022-07-30"
 tags: ["powershell","vscode","microsoft"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"3XigenZ3NoQOfHc4GKyYHx","contentType":"post","updatedAt":"2022-08-01T13:44:05.707Z"}
 ---
 
 ## 導入

--- a/src/content/blog/sign-git-commit-on-a-remote-host-using-the-key-on-a-piv-smart-card.mdx
+++ b/src/content/blog/sign-git-commit-on-a-remote-host-using-the-key-on-a-piv-smart-card.mdx
@@ -6,7 +6,6 @@ publishedOn: "2022-08-07"
 tags: ["gpg","yubikey"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"nP0ZtA1lHH1AUP9Byvd7I","contentType":"post","updatedAt":"2022-08-07T17:00:33.479Z"}
 ---
 
 ## 導入

--- a/src/content/blog/the-argument-password-store-gnome-does-not-work-in-vs-code-version-1.86.0-insider.mdx
+++ b/src/content/blog/the-argument-password-store-gnome-does-not-work-in-vs-code-version-1.86.0-insider.mdx
@@ -6,7 +6,6 @@ publishedOn: "2024-01-08"
 tags: ["vscode"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"7lENPr8p68Sm44sGUGzqEF","contentType":"post","updatedAt":"2024-05-18T10:48:27.730Z"}
 ---
 
 ## TL;DR

--- a/src/content/blog/the-issue-is-that-creds-are-not-used-correctly-when-aws-sso-creds-are-used-in-terraform-v1.5.4.mdx
+++ b/src/content/blog/the-issue-is-that-creds-are-not-used-correctly-when-aws-sso-creds-are-used-in-terraform-v1.5.4.mdx
@@ -6,7 +6,6 @@ publishedOn: "2023-08-06"
 tags: ["terrarofm"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"7z50s91Ne6iDACz6gNhVqP","contentType":"post","updatedAt":"2023-08-14T15:22:32.083Z"}
 ---
 
 ## TR;DR

--- a/src/content/blog/the-kvm-broke-when-i-didnt-do-anything.mdx
+++ b/src/content/blog/the-kvm-broke-when-i-didnt-do-anything.mdx
@@ -6,7 +6,6 @@ publishedOn: "2022-05-26"
 tags: ["essey","kvm","monitor","troubleshooting"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"74sfJy59WA6kA4s9gEeNQy","contentType":"post","updatedAt":"2022-07-20T11:50:47.285Z"}
 ---
 
 自身の備忘のために残す．

--- a/src/content/blog/time-discrepancy-in-windows-within-a-dual-boot-environment-with-linux.mdx
+++ b/src/content/blog/time-discrepancy-in-windows-within-a-dual-boot-environment-with-linux.mdx
@@ -6,7 +6,6 @@ publishedOn: "2024-01-30"
 tags: ["windows","clock","cmos","utc"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"4mzS7fJrryQE3BOHEYlBIt","contentType":"post","updatedAt":"2024-05-20T01:14:32.726Z"}
 ---
 
 ## 導入

--- a/src/content/blog/try-using-opentofu.mdx
+++ b/src/content/blog/try-using-opentofu.mdx
@@ -6,7 +6,6 @@ publishedOn: "2024-05-13"
 tags: ["opentofu","iac"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"3pEy7XRgp7t3FHsswrOmrP","contentType":"post","updatedAt":"2024-05-19T10:17:16.325Z"}
 ---
 
 ## 導入

--- a/src/content/blog/using-canon-pixus-xk70-with-nixos.mdx
+++ b/src/content/blog/using-canon-pixus-xk70-with-nixos.mdx
@@ -6,7 +6,6 @@ publishedOn: "2023-01-02"
 tags: ["nixos","canon"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"1WtIEBE4Era9nSkta6W4Pl","contentType":"post","updatedAt":"2023-01-11T04:41:21.321Z"}
 ---
 
 ## 導入

--- a/src/content/blog/using-flatpak-with-nixos.mdx
+++ b/src/content/blog/using-flatpak-with-nixos.mdx
@@ -6,7 +6,6 @@ publishedOn: "2023-01-07"
 tags: ["nixos","flatpak"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"2cQ8JdzG9VcShJ8Mge9TpN","contentType":"post","updatedAt":"2023-01-11T13:03:09.558Z"}
 ---
 
 ## 導入

--- a/src/content/blog/using-mdx-2-with-gatsby-and-contentful.mdx
+++ b/src/content/blog/using-mdx-2-with-gatsby-and-contentful.mdx
@@ -6,7 +6,6 @@ publishedOn: "2022-11-28"
 tags: ["gatsby"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"4FQRjG4Z3Lmcim3ekB9D20","contentType":"post","updatedAt":"2022-11-28T13:06:37.055Z"}
 ---
 
 ## 導入

--- a/src/content/blog/using-microsofts-c-cpp-extension-with-vs-code-on-nixos.mdx
+++ b/src/content/blog/using-microsofts-c-cpp-extension-with-vs-code-on-nixos.mdx
@@ -6,7 +6,6 @@ publishedOn: "2022-12-26"
 tags: ["vscode","microsoft","nixos"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"oiDuUOifpiwQLZarPFOFj","contentType":"post","updatedAt":"2022-12-28T12:24:33.359Z"}
 ---
 
 ## 導入

--- a/src/content/blog/using-self-built-terraform-provider-aws-with-opentofu.mdx
+++ b/src/content/blog/using-self-built-terraform-provider-aws-with-opentofu.mdx
@@ -6,7 +6,6 @@ publishedOn: "2024-05-17"
 tags: ["terraform","aws","go","opentofu"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"4DGzaAyu7qjay2kXyutY8d","contentType":"post","updatedAt":"2024-05-19T12:54:47.913Z"}
 ---
 
 ## 導入

--- a/src/content/blog/using-sip-phone-on-nixos.mdx
+++ b/src/content/blog/using-sip-phone-on-nixos.mdx
@@ -6,7 +6,6 @@ publishedOn: "2023-01-07"
 tags: ["nixos","jami","sip"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"5djnJwWfUMgVFIte5rcDtJ","contentType":"post","updatedAt":"2023-01-11T07:03:48.331Z"}
 ---
 
 ## 導入

--- a/src/content/blog/using-visual-studio-code-insiders-under-home-manager.mdx
+++ b/src/content/blog/using-visual-studio-code-insiders-under-home-manager.mdx
@@ -6,7 +6,6 @@ publishedOn: "2023-07-27"
 tags: ["vscode","nixos","home-manager"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"78PQ3AKWiIM7RjPHaF4M0f","contentType":"post","updatedAt":"2024-05-18T10:46:33.007Z"}
 ---
 
 ## TL;DR

--- a/src/content/blog/using-yubikey-for-git-signing-on-wsl2.mdx
+++ b/src/content/blog/using-yubikey-for-git-signing-on-wsl2.mdx
@@ -6,7 +6,6 @@ publishedOn: "2023-04-10"
 tags: ["windows","wsl2","git","gpg"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"5bKp79BOlgFM3aQStV2ZX1","contentType":"post","updatedAt":"2024-05-20T01:28:01.687Z"}
 ---
 
 ## 導入

--- a/src/content/blog/windows-hello-face-authentication-stopped-working-on-windows-11-pro.mdx
+++ b/src/content/blog/windows-hello-face-authentication-stopped-working-on-windows-11-pro.mdx
@@ -6,7 +6,6 @@ publishedOn: "2023-06-15"
 tags: ["windows","troubleshooting","webcam","hello"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"1mXOIXile0uJV3LuMoXBsE","contentType":"post","updatedAt":"2024-05-19T23:48:32.963Z"}
 ---
 
 この文章に読む価値はない．

--- a/src/content/blog/wordpress-to-gatsby.mdx
+++ b/src/content/blog/wordpress-to-gatsby.mdx
@@ -6,7 +6,6 @@ publishedOn: "2022-05-25"
 tags: ["essay","gatsby"]
 authors: [{"identity":"cariandrum22","name":"Takafumi Asano","emailAddress":"cariandrum22@gmail.com","profile":"I am a Software Engineer. I am currently working as a Director, VP of Products and VP of Engineering at codeTact Inc.","picture":{"title":"My old selfie","url":"/content-assets/contentful/1Q8kwuePvw2SDgcghjINSg/Photo_on_1-27-13_at_8.52_PM.jpg","contentType":"image/jpeg","width":640,"height":426}}]
 heroImage: {"title":"A sheep object at Thomas Land","description":"","url":"/content-assets/contentful/6Gvmcf6LWVu3vdX6H7lGZv/0W9A0652.jpg","contentType":"image/jpeg","width":2048,"height":1366}
-contentful: {"entryId":"2bPjigEaSIwUH8cXgcx0zz","contentType":"post","updatedAt":"2022-11-28T10:47:27.887Z"}
 ---
 
 ## WordPressが死んだ

--- a/src/content/pages/about.mdx
+++ b/src/content/pages/about.mdx
@@ -1,7 +1,6 @@
 ---
 title: "About"
 slug: "about"
-contentful: {"entryId":"4KVtphOu8Hcghx3PhA2us8","contentType":"page","updatedAt":"2024-05-19T10:19:19.205Z"}
 ---
 
 ## このサイトについて

--- a/src/content/pages/environments.mdx
+++ b/src/content/pages/environments.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Environments"
 slug: "environments"
-contentful: {"entryId":"4uZQ27uxQhq5IF3wznVFlT","contentType":"page","updatedAt":"2023-06-05T08:26:45.508Z"}
 ---
 
 # Environments

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -17,16 +17,9 @@ export type ContentAuthor = {
   profile?: Nullable<string>
 }
 
-export type ContentfulExportMetadata = {
-  contentType?: Nullable<string>
-  entryId?: Nullable<string>
-  updatedAt?: Nullable<string>
-}
-
 export type BlogPost = {
   authors?: Nullable<Array<ContentAuthor>>
   body: string
-  contentful?: Nullable<ContentfulExportMetadata>
   description?: Nullable<string>
   heroImage?: Nullable<ContentImage>
   publishedOn?: Nullable<string>
@@ -39,7 +32,6 @@ export type BlogPostPreview = Pick<BlogPost, "slug" | "title">
 
 export type PageContent = {
   body: string
-  contentful?: Nullable<ContentfulExportMetadata>
   slug?: Nullable<string>
   title?: Nullable<string>
 }


### PR DESCRIPTION
## Summary
- remove Contentful export metadata from local MDX frontmatter
- remove Contentful metadata from content types
- update content validation to reject Contentful export metadata in frontmatter

## Notes
- Historical article text mentioning Contentful is left unchanged
- Localized asset paths under /content-assets/contentful are left unchanged for this first step

## Verification
- nix develop --command pnpm run check:content
- nix develop --command pnpm run check:static
- nix develop --command pnpm run clean
- nix develop --command pnpm run build
- nix develop --command pnpm run check:build-output
- nix develop --command pnpm run check
- nix flake check
- nix develop --command pnpm install --frozen-lockfile --ignore-scripts
- nix develop --command pnpm install --frozen-lockfile
- git diff --check